### PR TITLE
fixing setup file

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,17 +1,15 @@
 #!/bin/sh
 
-CWD=`realpath $(dirname $0)`
-BINDATA_PKG="github.com/jteeuwen/go-bindata"
+CWD=`pwd`
+BINDATA_PKG="github.com/jteeuwen/go-bindata/..."
 
 if [ ! -n "${GOPATH}" ]; then
     echo "GOPATH not set"
     exit 255
 fi
 
-echo " # Get go-bindata"
-go get "$BINDATA_PKG"
-echo " # Install go-bindata"
-go install "$BINDATA_PKG"
+echo " # Get and install go-bindata"
+go get -u "$BINDATA_PKG"
 
 echo " # Generate files"
 exec $GOPATH/bin/go-bindata -pkg="storage" -o="${CWD}/storage/schemas.go" -prefix="${CWD}/storage" "${CWD}/storage/schemas/..."

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CWD=`pwd`
+CWD=`dirname "$(readlink -f "$0")"`
 BINDATA_PKG="github.com/jteeuwen/go-bindata/..."
 
 if [ ! -n "${GOPATH}" ]; then


### PR DESCRIPTION
dirname "$(readlink -f "$0")" works better for dir detection. realpath not installed on every machine

The installation of the lib hasn't worked for me in the setup. This one works and is the way documented in the lib README. Can you check if it works on your machine?
